### PR TITLE
Models for blocks & parent templates now supported

### DIFF
--- a/src/Twig/Node/DisplayEndNode.php
+++ b/src/Twig/Node/DisplayEndNode.php
@@ -39,17 +39,13 @@ final class DisplayEndNode extends Node
      */
     public function compile(Compiler $compiler)
     {
-        if ($this->module->hasAttribute('is_embedded')) {
-            return;
-        }
-
         $extension = Extension::class;
         $templateName = $this->getTemplateName();
         $view = View::class;
 
         $compiler
             ->raw("\n")
-            ->write("if (\$suppressedException instanceof \\Shoot\\Shoot\\SuppressedException) {\n")
+            ->write("if (\$suppressedException instanceof Shoot\\Shoot\\SuppressedException) {\n")
             ->indent()
             ->write("throw \$suppressedException;\n")
             ->outdent()

--- a/src/Twig/Node/DisplayStartNode.php
+++ b/src/Twig/Node/DisplayStartNode.php
@@ -43,15 +43,12 @@ final class DisplayStartNode extends Node
      */
     public function compile(Compiler $compiler)
     {
-        if ($this->module->hasAttribute('is_embedded')) {
-            return;
-        }
-
         $presentationModel = $this->findPresentationModel->for($this->getTemplateName());
 
         $compiler
-            ->write("\$presentationModel = new $presentationModel(\$context);\n\n")
-            ->write("\$callback = function (array \$context) use (\$blocks) {\n")
+            ->write("\$presentationModel = new $presentationModel(\$context);\n")
+            ->write("\$originalContext = \$context;\n\n")
+            ->write("\$callback = function (array \$context) use (\$blocks, \$originalContext) {\n")
             ->indent()
             ->write("\$suppressedException = null;\n\n");
     }

--- a/src/Twig/Node/OptionalNode.php
+++ b/src/Twig/Node/OptionalNode.php
@@ -35,14 +35,14 @@ final class OptionalNode extends Node
             ->indent()
             ->subcompile($this->getNode('body'))
             ->outdent()
-            ->write("} catch (\\Twig_Error_Runtime \$exception) {\n")
+            ->write("} catch (Twig_Error_Runtime \$exception) {\n")
             ->indent()
             ->write("if (\$exception->getPrevious() === null) {\n")
             ->indent()
             ->write("throw \$exception;\n")
             ->outdent()
             ->write("}\n\n")
-            ->write("\$suppressedException = new \\Shoot\\Shoot\\SuppressedException(\$exception->getPrevious());\n")
+            ->write("\$suppressedException = new Shoot\\Shoot\\SuppressedException(\$exception->getPrevious());\n")
             ->outdent()
             ->write("}\n\n");
     }

--- a/src/Twig/NodeVisitor/ModelNodeVisitor.php
+++ b/src/Twig/NodeVisitor/ModelNodeVisitor.php
@@ -52,13 +52,6 @@ final class ModelNodeVisitor implements FindPresentationModelInterface, NodeVisi
             return $node;
         }
 
-        if ($node->hasAttribute('embedded_templates')) {
-            /** @var ModuleNode $embeddedTemplate */
-            foreach ($node->getAttribute('embedded_templates') as $embeddedTemplate) {
-                $embeddedTemplate->setAttribute('is_embedded', true);
-            }
-        }
-
         $node->setNode('display_start', new DisplayStartNode($node, $this));
         $node->setNode('display_end', new DisplayEndNode($node));
 

--- a/src/Twig/PatchingCompiler.php
+++ b/src/Twig/PatchingCompiler.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Twig;
+
+use Twig_Compiler as Compiler;
+
+/**
+ * This compiler patches a few crucial lines in some core Twig classes. It allows Shoot to be used with extend, embed,
+ * and blocks. Out of all hacks to make that work, this one seemed to be the most straightforward.
+ *
+ * @internal
+ */
+final class PatchingCompiler extends Compiler
+{
+    /**
+     * @param mixed $string
+     *
+     * @return Compiler
+     */
+    public function raw($string)
+    {
+        return parent::raw($this->patch($string));
+    }
+
+    /**
+     * @param mixed[] ...$strings
+     *
+     * @return Compiler
+     */
+    public function write(...$strings)
+    {
+        $strings = array_map([$this, 'patch'], $strings);
+
+        return parent::write(...$strings);
+    }
+
+    /**
+     * @param mixed $string
+     *
+     * @return mixed
+     */
+    private function patch($string)
+    {
+        static $patterns = [
+            '/(->display\()\$context(, array_merge\(\$this->blocks, \$blocks\)\);\n)/',
+            '/(\$this->displayBlock\(\'[^\']+\', )\$context(, \$blocks\);\n)/',
+        ];
+
+        return !is_string($string) ? $string : preg_replace($patterns, '$1array_merge($originalContext, $context)$2', $string);
+    }
+}

--- a/tests/Fixtures/Embedded.php
+++ b/tests/Fixtures/Embedded.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Fixtures;
+
+use Shoot\Shoot\HasPresenterInterface;
+use Shoot\Shoot\PresentationModel;
+
+final class Embedded extends PresentationModel implements HasPresenterInterface
+{
+    /** @var string */
+    protected $subtitle = '';
+
+    /** @var string */
+    protected $title = '';
+
+    /**
+     * Returns the name by which to resolve the presenter through the DI container.
+     *
+     * @return string
+     */
+    public function getPresenterName(): string
+    {
+        return EmbeddedPresenter::class;
+    }
+}

--- a/tests/Fixtures/EmbeddedPresenter.php
+++ b/tests/Fixtures/EmbeddedPresenter.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Fixtures;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Shoot\Shoot\PresentationModel;
+use Shoot\Shoot\PresenterInterface;
+
+final class EmbeddedPresenter implements PresenterInterface
+{
+    /**
+     * Receives the current HTTP request context and the presentation model assigned to the view. If necessary,
+     * populates the presentation model with data and returns it.
+     *
+     * @param ServerRequestInterface $request
+     * @param PresentationModel      $presentationModel
+     *
+     * @return PresentationModel
+     */
+    public function present(ServerRequestInterface $request, PresentationModel $presentationModel): PresentationModel
+    {
+        return $presentationModel->withVariables(['subtitle' => 'subtitle']);
+    }
+}

--- a/tests/Fixtures/Layout.php
+++ b/tests/Fixtures/Layout.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Fixtures;
+
+use Shoot\Shoot\HasPresenterInterface;
+use Shoot\Shoot\PresentationModel;
+
+final class Layout extends PresentationModel implements HasPresenterInterface
+{
+    /** @var string */
+    protected $title = '';
+
+    /**
+     * Returns the name by which to resolve the presenter through the DI container.
+     *
+     * @return string
+     */
+    public function getPresenterName(): string
+    {
+        return LayoutPresenter::class;
+    }
+}

--- a/tests/Fixtures/LayoutPresenter.php
+++ b/tests/Fixtures/LayoutPresenter.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Fixtures;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Shoot\Shoot\PresentationModel;
+use Shoot\Shoot\PresenterInterface;
+
+final class LayoutPresenter implements PresenterInterface
+{
+    /**
+     * Receives the current HTTP request context and the presentation model assigned to the view. If necessary,
+     * populates the presentation model with data and returns it.
+     *
+     * @param ServerRequestInterface $request
+     * @param PresentationModel      $presentationModel
+     *
+     * @return PresentationModel
+     */
+    public function present(ServerRequestInterface $request, PresentationModel $presentationModel): PresentationModel
+    {
+        return $presentationModel->withVariables(['title' => 'title']);
+    }
+}

--- a/tests/Fixtures/Page.php
+++ b/tests/Fixtures/Page.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Fixtures;
+
+use Shoot\Shoot\HasPresenterInterface;
+use Shoot\Shoot\PresentationModel;
+
+final class Page extends PresentationModel implements HasPresenterInterface
+{
+    /** @var string */
+    protected $body = '';
+
+    /**
+     * Returns the name by which to resolve the presenter through the DI container.
+     *
+     * @return string
+     */
+    public function getPresenterName(): string
+    {
+        return PagePresenter::class;
+    }
+}

--- a/tests/Fixtures/PagePresenter.php
+++ b/tests/Fixtures/PagePresenter.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Fixtures;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Shoot\Shoot\PresentationModel;
+use Shoot\Shoot\PresenterInterface;
+
+final class PagePresenter implements PresenterInterface
+{
+    /**
+     * Receives the current HTTP request context and the presentation model assigned to the view. If necessary,
+     * populates the presentation model with data and returns it.
+     *
+     * @param ServerRequestInterface $request
+     * @param PresentationModel      $presentationModel
+     *
+     * @return PresentationModel
+     */
+    public function present(ServerRequestInterface $request, PresentationModel $presentationModel): PresentationModel
+    {
+        return $presentationModel->withVariables(['body' => 'body']);
+    }
+}

--- a/tests/Fixtures/Templates/embedded_template.twig
+++ b/tests/Fixtures/Templates/embedded_template.twig
@@ -1,4 +1,6 @@
+{% model 'Shoot\\Shoot\\Tests\\Fixtures\\Embedded' %}
 # title: {{ title }}
+## subtitle: {{ subtitle }}
 {% block content %}
     placeholder
 {% endblock %}

--- a/tests/Fixtures/Templates/has_embedded_template.twig
+++ b/tests/Fixtures/Templates/has_embedded_template.twig
@@ -1,7 +1,3 @@
-{##
- # The embedded template does not match the model of the parent template. For embedded templates, Shoot should allow all
- # variables to pass through.
- #}
 {% model 'Shoot\\Shoot\\Tests\\Fixtures\\Item' %}
 {% embed 'embedded_template.twig' with { title: name } %}
     {% block content %}

--- a/tests/Fixtures/Templates/layout.twig
+++ b/tests/Fixtures/Templates/layout.twig
@@ -1,0 +1,9 @@
+{% model 'Shoot\\Shoot\\Tests\\Fixtures\\Layout' %}
+<!doctype html>
+<head>
+    <title>{{ title }}</title>
+</head>
+<body>
+{% block body %}
+{% endblock %}
+</body>

--- a/tests/Fixtures/Templates/page.twig
+++ b/tests/Fixtures/Templates/page.twig
@@ -1,0 +1,5 @@
+{% model 'Shoot\\Shoot\\Tests\\Fixtures\\Page' %}
+{% extends 'layout.twig' %}
+{% block body %}
+    <h1>{{ body }}</h1>
+{% endblock %}


### PR DESCRIPTION
Added support for use of models for extends, embed, and blocks by patching Twig’s compiler. The correct model is now used in each case.