### PR TITLE
Fix for missing $originalContext variable

### DIFF
--- a/src/Twig/PatchingCompiler.php
+++ b/src/Twig/PatchingCompiler.php
@@ -47,6 +47,6 @@ final class PatchingCompiler extends Compiler
             '/(\$this->displayBlock\(\'[^\']+\', )\$context(, \$blocks\);\n)/',
         ];
 
-        return !is_string($string) ? $string : preg_replace($patterns, '$1array_merge($originalContext, $context)$2', $string);
+        return !is_string($string) ? $string : preg_replace($patterns, '$1array_merge($originalContext ?? [], $context)$2', $string);
     }
 }


### PR DESCRIPTION
The patch is applied regardless of context, so the $originalContext variable may be missing. This fix takes that into account.