### PR TITLE
Added Shoot installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ $ composer require shoot/shoot
 First, set up the pipeline. All views being rendered by Twig pass through it, and are processed by Shoot's middleware.
 For Shoot to be useful, you'll need at least the `PresenterMiddleware`, which takes a DI container as its dependency.
 
-All that's left is then to add the extension to Twig:
+All that's left is then to install Shoot in Twig:
 
 ```php
 $middleware = [new PresenterMiddleware($container)];
 $pipeline = new Pipeline($middleware);
-$extension = new Extension($pipeline);
+$installer = new Installer($pipeline);
 
-$twig->addExtension($extension);
+$twig = $installer->install($twig);
 ```
 
 With Shoot now set up, let's take a look at an example of how you can use it.

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -15,6 +15,8 @@ use Twig_TokenParserInterface as TokenParserInterface;
 
 /**
  * This extension for Twig will enable the use of Shoot.
+ *
+ * @internal
  */
 final class Extension implements ExtensionInterface
 {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot;
+
+use Shoot\Shoot\Twig\PatchingCompiler;
+use Twig_Environment as Environment;
+
+/**
+ * Installs Shoot in an instance of Twig.
+ */
+final class Installer
+{
+    /** @var Pipeline */
+    private $pipeline;
+
+    /**
+     * @param Pipeline $pipeline
+     */
+    public function __construct(Pipeline $pipeline)
+    {
+        $this->pipeline = $pipeline;
+    }
+
+    /**
+     * Returns a Twig instance with Shoot installed. Does not modify the original instance.
+     *
+     * @param Environment $twig
+     *
+     * @return Environment
+     */
+    public function install(Environment $twig): Environment
+    {
+        $twig = clone $twig;
+
+        $extension = new Extension($this->pipeline);
+        $twig->addExtension($extension);
+
+        $compiler = new PatchingCompiler($twig);
+        $twig->setCompiler($compiler);
+
+        return $twig;
+    }
+}

--- a/src/Twig/PatchingCompiler.php
+++ b/src/Twig/PatchingCompiler.php
@@ -47,6 +47,8 @@ final class PatchingCompiler extends Compiler
             '/(\$this->displayBlock\(\'[^\']+\', )\$context(, \$blocks\);\n)/',
         ];
 
-        return !is_string($string) ? $string : preg_replace($patterns, '$1array_merge($originalContext ?? [], $context)$2', $string);
+        return !is_string($string)
+            ? $string
+            : preg_replace($patterns, '$1array_merge($originalContext ?? [], $context)$2', $string);
     }
 }

--- a/tests/TwigIntegrationTest.php
+++ b/tests/TwigIntegrationTest.php
@@ -6,11 +6,10 @@ namespace Shoot\Shoot\Tests;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
-use Shoot\Shoot\Extension;
+use Shoot\Shoot\Installer;
 use Shoot\Shoot\Middleware\PresenterMiddleware;
 use Shoot\Shoot\Pipeline;
 use Shoot\Shoot\Tests\Mocks\ContainerStub;
-use Shoot\Shoot\Twig\PatchingCompiler;
 use Twig_Environment as Environment;
 use Twig_Error_Runtime;
 use Twig_Loader_Filesystem as FilesystemLoader;
@@ -33,12 +32,11 @@ final class TwigIntegrationTest extends TestCase
     {
         $container = new ContainerStub();
         $pipeline = new Pipeline([new PresenterMiddleware($container)]);
-        $extension = new Extension($pipeline);
+        $installer = new Installer($pipeline);
 
         $loader = new FilesystemLoader([realpath(__DIR__ . '/Fixtures/Templates')]);
         $twig = new Environment($loader, ['cache' => false, 'strict_variables' => true]);
-        $twig->addExtension($extension);
-        $twig->setCompiler(new PatchingCompiler($twig));
+        $twig = $installer->install($twig);
 
         $this->pipeline = $pipeline;
         $this->request = $this->createMock(ServerRequestInterface::class);


### PR DESCRIPTION
With the installer, adding Shoot to Twig is now slightly easier for the end user. The real benefit is that how Shoot is installed in Twig is now encapsulated and should reduce future breaking changes.