### PR TITLE
Undo regression in embedding templates

### DIFF
--- a/src/Twig/Node/DisplayEndNode.php
+++ b/src/Twig/Node/DisplayEndNode.php
@@ -39,6 +39,10 @@ final class DisplayEndNode extends Node
      */
     public function compile(Compiler $compiler)
     {
+        if ($this->module->hasAttribute('is_embedded')) {
+            return;
+        }
+
         $extension = Extension::class;
         $templateName = $this->getTemplateName();
         $view = View::class;

--- a/src/Twig/Node/DisplayStartNode.php
+++ b/src/Twig/Node/DisplayStartNode.php
@@ -43,6 +43,10 @@ final class DisplayStartNode extends Node
      */
     public function compile(Compiler $compiler)
     {
+        if ($this->module->hasAttribute('is_embedded')) {
+            return;
+        }
+
         $presentationModel = $this->findPresentationModel->for($this->getTemplateName());
 
         $compiler

--- a/src/Twig/NodeVisitor/ModelNodeVisitor.php
+++ b/src/Twig/NodeVisitor/ModelNodeVisitor.php
@@ -52,6 +52,13 @@ final class ModelNodeVisitor implements FindPresentationModelInterface, NodeVisi
             return $node;
         }
 
+        if ($node->hasAttribute('embedded_templates')) {
+            /** @var ModuleNode $embeddedTemplate */
+            foreach ($node->getAttribute('embedded_templates') as $embeddedTemplate) {
+                $embeddedTemplate->setAttribute('is_embedded', true);
+            }
+        }
+
         $node->setNode('display_start', new DisplayStartNode($node, $this));
         $node->setNode('display_end', new DisplayEndNode($node));
 

--- a/tests/Integration/Embedding/EmbeddingTest.php
+++ b/tests/Integration/Embedding/EmbeddingTest.php
@@ -66,8 +66,6 @@ final class EmbeddingTest extends IntegrationTestCase
      */
     public function testPresentersShouldOnlyBeCalledOnce()
     {
-        $this->markTestSkipped('Presenters should only be called once: currently fails, fix pending.');
-
         $this->pagePresenter
             ->expects($this->once())
             ->method('present');

--- a/tests/Integration/Embedding/Templates/page.twig
+++ b/tests/Integration/Embedding/Templates/page.twig
@@ -1,7 +1,7 @@
 {% model 'Shoot\\Shoot\\Tests\\Integration\\Embedding\\Models\\Page' %}
 {% extends 'base.twig' %}
 {% block body %}
-    {% embed 'layout.twig' with { main_class: 'main--overriden'} only %}
+    {% embed 'layout.twig' with { main_class: 'main--overriden'} %}
         {% block main %}
             <h1>{{ title }}</h1>
             <p>{{ content }}</p>


### PR DESCRIPTION
This fixes a regression that occured as a result of adding support for inheritance and blocks that caused presenters to be invoked multiple times. Test coverage was added in 697c47790fbf664c8ccc98a509eded022e19689a.