### PR TITLE
Fix for inherited variables

### DIFF
--- a/src/Twig/PatchingCompiler.php
+++ b/src/Twig/PatchingCompiler.php
@@ -49,6 +49,6 @@ final class PatchingCompiler extends Compiler
 
         return !is_string($string)
             ? $string
-            : preg_replace($patterns, '$1array_merge($originalContext ?? [], $context)$2', $string);
+            : preg_replace($patterns, '$1array_merge($context, $originalContext ?? [])$2', $string);
     }
 }

--- a/tests/Integration/Embedding/EmbeddingTest.php
+++ b/tests/Integration/Embedding/EmbeddingTest.php
@@ -47,6 +47,7 @@ final class EmbeddingTest extends IntegrationTestCase
     {
         $output = $this->renderTemplate('page.twig');
 
+        $this->assertContains('<title>page_title</title>', $output);
         $this->assertContains('<h1>page_title</h1>', $output);
         $this->assertContains('<p>page_content</p>', $output);
     }

--- a/tests/Integration/Embedding/Models/Base.php
+++ b/tests/Integration/Embedding/Models/Base.php
@@ -3,10 +3,22 @@ declare(strict_types=1);
 
 namespace Shoot\Shoot\Tests\Integration\Embedding\Models;
 
+use Shoot\Shoot\HasPresenterInterface;
 use Shoot\Shoot\PresentationModel;
+use Shoot\Shoot\Tests\Integration\Embedding\Presenters\BasePresenter;
 
-final class Base extends PresentationModel
+final class Base extends PresentationModel implements HasPresenterInterface
 {
     /** @var string */
-    protected $title = 'base_title';
+    protected $title = '';
+
+    /**
+     * Returns the name by which to resolve the presenter through the DI container.
+     *
+     * @return string
+     */
+    public function getPresenterName(): string
+    {
+        return BasePresenter::class;
+    }
 }

--- a/tests/Integration/Embedding/Presenters/BasePresenter.php
+++ b/tests/Integration/Embedding/Presenters/BasePresenter.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Shoot\Shoot\Tests\Integration\Embedding\Presenters;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Shoot\Shoot\PresentationModel;
+use Shoot\Shoot\PresenterInterface;
+
+final class BasePresenter implements PresenterInterface
+{
+    /**
+     * Receives the current HTTP request context and the presentation model assigned to the view. If necessary,
+     * populates the presentation model with data and returns it.
+     *
+     * @param ServerRequestInterface $request
+     * @param PresentationModel      $presentationModel
+     *
+     * @return PresentationModel
+     */
+    public function present(ServerRequestInterface $request, PresentationModel $presentationModel): PresentationModel
+    {
+        return $presentationModel->withVariables([
+            'title' => 'base_title'
+        ]);
+    }
+}


### PR DESCRIPTION
Variables of child templates were overridden by their parents. This commit fixes that and adds test coverage.