### PR TITLE
Bumps twig to 2.12/3.0 for PHP 7.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to Shoot will be documented in this file.
 
+## [3.2.0] - 2019-12-10
+### Changed
+- Twig has been bumped to v2.12 and/or v3.0.
+
 ## [3.1.0] - 2019-06-18
 ### Changed
 - Twig has been bumped to v2.11.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.1",
-        "twig/twig": "~2.11.0"
+        "twig/twig": "^2.12.0 || ^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.1"


### PR DESCRIPTION
2.12 fixes an issue where array_key_exists is used on objects, which generates an E_DEPRECATED level error in PHP 7.4