### PR TITLE
Only process templates with presentation model through pipeline

### DIFF
--- a/src/Twig/NodeVisitor/ModelNodeVisitor.php
+++ b/src/Twig/NodeVisitor/ModelNodeVisitor.php
@@ -58,6 +58,10 @@ final class ModelNodeVisitor implements FindPresentationModelInterface, NodeVisi
             return $node;
         }
 
+        if (!isset($this->presentationModels[$node->getSourceContext()])) {
+            return $node;
+        }
+
         if ($node->hasAttribute('embedded_templates')) {
             /** @var ModuleNode $embeddedTemplate */
             foreach ($node->getAttribute('embedded_templates') as $embeddedTemplate) {


### PR DESCRIPTION
Right now Shoot will add a wrapper around every Twig node that is rendered. Even if those nodes do not have a presentation model associated to it. This has a significant impact on render time, especially when rendering a lot of small templates without presentation models.

This PR will make sure Shoot only adds the wrapper when it needs to do that, so only when there is a presentation model present.

I've measured the time it takes to render an empty template 100.000 times. Below are three runs of that test per scenario. The results are the time it takes in seconds to render the empty template once.

Current:
1.6900370121002E-5
1.8089079856873E-5
1.6964430809021E-5

Without any middleware
1.3252210617065E-5
1.3505561351776E-5
1.347021818161E-5

After this change:
1.1957528591156E-5
1.1988968849182E-5
1.1879818439484E-5

